### PR TITLE
Fix MSBuild generate invocation

### DIFF
--- a/src/plugins/generator/visualstudio/msbuildsharedsolutionpropertiesproject.cpp
+++ b/src/plugins/generator/visualstudio/msbuildsharedsolutionpropertiesproject.cpp
@@ -92,7 +92,12 @@ static QString qbsCommandLine(const GeneratableProject &project,
         commandLine.appendArgument(QStringLiteral("--force-probe-execution"));
     }
 
-    addEnvironmentVariableArgument(commandLine, QStringLiteral("Configuration"));
+    if (subCommand == QStringLiteral("generate")) {
+        commandLine.appendRawArgument(QStringLiteral("config:$(Configuration)"));
+    }
+    else {
+        addEnvironmentVariableArgument(commandLine, QStringLiteral("Configuration"));
+    }
 
     return commandLine.toCommandLine(Internal::HostOsInfo::HostOsWindows);
 }


### PR DESCRIPTION
Generate does not expect a build raw configuration.

Old `generate` commandLine results in this error:
```
2>EXEC : error : Unexpected command line parameter 'Debug'.
2>Expected an assignment of the form <property>:<value>, profile:<profile-name> or config:<configuration-name>.
```