### PR TITLE
bare-metal: Long live for IAR ARM toolchain support on Windows

### DIFF
--- a/share/qbs/imports/qbs/Probes/IarProbe.qbs
+++ b/share/qbs/imports/qbs/Probes/IarProbe.qbs
@@ -1,0 +1,71 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 Denis Shienkov <denis.shienkov@gmail.com>
+** Contact: http://www.qt.io/licensing
+**
+** This file is part of the Qt Build Suite.
+**
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms and
+** conditions see http://www.qt.io/terms-conditions. For further information
+** use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file.  Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, The Qt Company gives you certain additional
+** rights.  These rights are described in The Qt Company LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+****************************************************************************/
+
+import qbs
+import qbs.File
+import qbs.FileInfo
+import qbs.Process
+import qbs.ModUtils
+import qbs.Utilities
+import "../../../modules/cpp/iar.js" as IAR
+
+PathProbe {
+    // Inputs
+    property string compilerFilePath;
+    property string preferredArchitecture;
+
+    property string _nullDevice: qbs.nullDevice
+
+    // Outputs
+    property string architecture;
+    property string endianness;
+    property int versionMajor;
+    property int versionMinor;
+    property int versionPatch;
+
+    configure: {
+        if (!File.exists(compilerFilePath)) {
+            found = false;
+            return;
+        }
+
+        var macros = IAR.dumpMacros(compilerFilePath, qbs, _nullDevice);
+
+        architecture = IAR.guessArchitecture(macros);
+        endianness = IAR.guessEndianness(macros);
+
+        var version = parseInt(macros['__VER__'], 10);
+        versionMajor = parseInt(version / 1000000);
+        versionMinor = parseInt(version / 1000) % 1000;
+        versionPatch = parseInt(version) % 1000;
+
+        found = version && architecture && endianness;
+   }
+}

--- a/share/qbs/modules/cpp/iar.js
+++ b/share/qbs/modules/cpp/iar.js
@@ -279,6 +279,31 @@ function linkerFlags(project, product, input, outputs) {
     return args;
 }
 
+function converterFlags(project, product, input, outputs) {
+    var args = [];
+
+    switch (product.cpp.additionalOutputFormat) {
+    case "intel":
+        args.push('--ihex');
+        break;
+    case "motorola":
+        args.push('--srec');
+        break;
+    case "binary":
+        args.push('--bin');
+        break;
+    case "simple":
+        args.push('--simple');
+        break;
+    }
+
+    args.push('--verbose');
+    args.push(input.filePath);
+    args.push(outputs.hex_file[0].filePath);
+
+    return args;
+}
+
 function prepareCompiler(project, product, inputs, outputs, input, output, explicitlyDependsOn) {
     var args = compilerFlags(project, product, input, output, explicitlyDependsOn);
     var compilerPath = product.cpp.compilerPath;
@@ -306,6 +331,17 @@ function prepareLinker(project, product, inputs, outputs, input, output) {
     var linkerPath = product.cpp.linkerPath;
     var cmd = new Command(linkerPath, args)
     cmd.description = 'linking ' + primaryOutput.fileName;
+    cmd.highlight = "linker";
+    cmd.workingDirectory = product.buildDirectory;
+    return [cmd];
+}
+
+function prepareConverter(project, product, inputs, outputs, input, output) {
+    var primaryOutput = outputs.hex_file[0];
+    var args = converterFlags(project, product, input, outputs);
+    var converterPath = product.cpp.converterPath;
+    var cmd = new Command(converterPath, args)
+    cmd.description = 'generating ' + primaryOutput.fileName;
     cmd.highlight = "linker";
     cmd.workingDirectory = product.buildDirectory;
     return [cmd];

--- a/share/qbs/modules/cpp/iar.js
+++ b/share/qbs/modules/cpp/iar.js
@@ -239,7 +239,7 @@ function assemblerFlags(project, product, input, output, explicitlyDependsOn) {
     return args;
 }
 
-function linkerFlags(project, product, input, output) {
+function linkerFlags(project, product, input, outputs) {
     var i;
     var args = [];
 
@@ -252,7 +252,10 @@ function linkerFlags(project, product, input, output) {
         args.push(redirects[i]);
     }
 
-    args.push('-o', output.filePath);
+    args.push('-o', outputs.application[0].filePath);
+
+    if (product.cpp.generateMapFile)
+        args.push('--map', outputs.map_file[0].filePath);
 
     var linkerScripts = inputs.linkerscript
             ? inputs.linkerscript.map(function(a) { return a.filePath; }) : [];
@@ -299,7 +302,7 @@ function prepareAssembler(project, product, inputs, outputs, input, output, expl
 
 function prepareLinker(project, product, inputs, outputs, input, output) {
     var primaryOutput = outputs.application[0];
-    var args = linkerFlags(project, product, input, output);
+    var args = linkerFlags(project, product, input, outputs);
     var linkerPath = product.cpp.linkerPath;
     var cmd = new Command(linkerPath, args)
     cmd.description = 'linking ' + primaryOutput.fileName;

--- a/share/qbs/modules/cpp/iar.js
+++ b/share/qbs/modules/cpp/iar.js
@@ -220,8 +220,12 @@ function assemblerFlags(project, product, input, output, explicitlyDependsOn) {
     else
         args.push('-w+');
 
-    // Enable sensitivity for user symbols.
-    args.push('-s+');
+    // Case sensitivity for user symbols.
+    var sensitivity = input.cpp.enableSymbolsCaseSensitivity;
+    if (sensitivity)
+        args.push('-s+');
+    else
+        args.push('-s-');
 
     // ASM macro argument quotes.
     var quotes = input.cpp.macroQuoteCharacters;

--- a/share/qbs/modules/cpp/iar.js
+++ b/share/qbs/modules/cpp/iar.js
@@ -214,7 +214,7 @@ function assemblerFlags(project, product, input, output, explicitlyDependsOn) {
     if (input.cpp.debugInformation)
         args.push('-r');
 
-    var warnings = input.cpp.warningLevel
+    var warnings = input.cpp.warningLevel;
     if (warnings === 'none')
         args.push('-w-');
     else
@@ -224,7 +224,9 @@ function assemblerFlags(project, product, input, output, explicitlyDependsOn) {
     args.push('-s+');
 
     // ASM macro argument quotes.
-    args.push('-M<>');
+    var quotes = input.cpp.macroQuoteCharacters;
+    if (quotes)
+        args.push('-M' + quotes);
 
     args.push('-o', output.filePath);
 

--- a/share/qbs/modules/cpp/iar.js
+++ b/share/qbs/modules/cpp/iar.js
@@ -1,0 +1,303 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 Denis Shienkov <denis.shienkov@gmail.com>
+** Contact: http://www.qt.io/licensing
+**
+** This file is part of the Qt Build Suite.
+**
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms and
+** conditions see http://www.qt.io/terms-conditions. For further information
+** use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file.  Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, The Qt Company gives you certain additional
+** rights.  These rights are described in The Qt Company LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+****************************************************************************/
+
+var Cpp = require("cpp.js");
+var Environment = require("qbs.Environment");
+var File = require("qbs.File");
+var FileInfo = require("qbs.FileInfo");
+var ModUtils = require("qbs.ModUtils");
+var Process = require("qbs.Process");
+var TextFile = require("qbs.TextFile");
+var Utilities = require("qbs.Utilities");
+var WindowsUtils = require("qbs.WindowsUtils");
+
+function guessArchitecture(macros)
+{
+    if (macros['__ICCARM__'] === '1')
+        return 'arm';
+}
+
+function guessEndianness(macros)
+{
+    if (macros['__LITTLE_ENDIAN__'] === '1')
+        return 'little';
+}
+
+function dumpMacros(compilerFilePath, qbs, nullDevice) {
+    var fn = FileInfo.fromNativeSeparators(Environment.getEnv('TEMP') + '/iar-macros.predef');
+    var p = new Process();
+    try {
+        p.exec(compilerFilePath,
+               [ nullDevice, '--predef_macros', fn ],
+               true);
+        try {
+            var tf = new TextFile(fn, TextFile.ReadOnly);
+            var map = {};
+            tf.readAll().trim().split(/\r?\n/g).map(function (line) {
+                var parts = line.split(" ", 3);
+                map[parts[1]] = parts[2];
+            });
+            return map;
+        } finally {
+            if (tf)
+                tf.close();
+        }
+    } finally {
+        p.close();
+    }
+}
+
+function targetCores(input) {
+    var cores = [];
+    var cpu = input.cpp.cpu;
+    if (cpu) {
+        cores.push('--cpu');
+        cores.push(cpu);
+    }
+    var fpu = input.cpp.fpu;
+    if (fpu) {
+        cores.push('--fpu');
+        cores.push(fpu);
+    }
+    return cores;
+}
+
+function compilerFlags(project, product, input, output, explicitlyDependsOn) {
+    // Determine which C-language we're compiling.
+    var tag = ModUtils.fileTagForTargetLanguage(input.fileTags.concat(output.fileTags));
+    if (!['c', 'cpp'].contains(tag))
+        throw ('unsupported source language');
+
+    var i;
+    var args = [];
+    args.push(input.filePath);
+    args = args.concat(targetCores(input));
+
+    switch (input.cpp.optimization) {
+    case "small":
+        args.push('-Ohs');
+        break;
+    case "fast":
+        args.push('-Ohz');
+        break;
+    case "none":
+        args.push("-On");
+        break;
+    }
+
+    // Enable IAR C/C++ language extensions.
+    args.push('-e');
+
+    if (input.cpp.debugInformation) {
+        args.push('--debug');
+        // Disable static clustering for static and global variables.
+        args.push('--no_clustering');
+        // Disable code motion.
+        args.push('--no_code_motion');
+        // Disable common sub-expression elimination.
+        args.push('--no_cse');
+        // Disable function inlining.
+        args.push('--no_inline');
+        // Disable instruction scheduling.
+        args.push('--no_scheduling');
+        // Disable type based alias analysis.
+        args.push('--no_tbaa');
+        // Disable loop unrolling.
+        args.push('--no_unroll');
+    }
+
+    var warnings = input.cpp.warningLevel;
+    if (warnings === 'none') {
+        args.push('--no_warnings');
+    } else if (warnings === 'all') {
+        args.push('--warnings_affect_exit_code');
+        args.push('--warn_about_c_style_casts');
+    }
+    if (input.cpp.treatWarningsAsErrors) {
+        args.push('--warnings_are_errors');
+    }
+
+    // Choose byte order.
+    var endianness = input.cpp.endianness;
+    if (endianness)
+        args.push('--endian=' + endianness);
+
+    // Specify DLib library configuration.
+    var dlibPath = input.cpp.toolchainInstallPath + "/../inc/c/DLib_Config_Full.h";
+    args.push('--dlib_config', dlibPath);
+
+    if (tag === 'c') {
+        // Language version.
+        if (input.cpp.cLanguageVersion === 'c89')
+            args.push('--c89');
+    } else if (tag === 'cpp') {
+        args.push('--c++');
+        if (!input.cpp.enableExceptions)
+            args.push('--no_exceptions');
+        if (!input.cpp.enableRtti)
+            args.push('--no_rtti');
+        if (!input.cpp.enableStaticDestruction)
+            args.push('--no_static_destruction');
+    }
+
+    var allDefines = [];
+    var platformDefines = input.cpp.platformDefines;
+    if (platformDefines)
+        allDefines = allDefines.uniqueConcat(platformDefines);
+    var defines = input.cpp.defines;
+    if (defines)
+        allDefines = allDefines.uniqueConcat(defines);
+    args = args.concat(allDefines.map(function(define) { return '-D' + define }));
+
+    var allIncludePaths = [];
+    if (input.cpp.enableCmsis) {
+        var cmsisIncludePath = input.cpp.toolchainInstallPath + "/../CMSIS/Include/";
+        allIncludePaths.push(cmsisIncludePath);
+    }
+    var includePaths = input.cpp.includePaths;
+    if (includePaths)
+        allIncludePaths = allIncludePaths.uniqueConcat(includePaths);
+    var systemIncludePaths = input.cpp.systemIncludePaths;
+    if (systemIncludePaths)
+        allIncludePaths = allIncludePaths.uniqueConcat(systemIncludePaths);
+    var compilerIncludePaths = input.cpp.compilerIncludePaths;
+    if (compilerIncludePaths)
+        allIncludePaths = allIncludePaths.uniqueConcat(compilerIncludePaths);
+    args = args.concat(allIncludePaths.map(function(include) { return '-I' + include }));
+
+    args.push('-o', output.filePath);
+
+    args = args.concat(ModUtils.moduleProperty(input, 'platformFlags'),
+                       ModUtils.moduleProperty(input, 'flags'),
+                       ModUtils.moduleProperty(input, 'platformFlags', tag),
+                       ModUtils.moduleProperty(input, 'flags', tag));
+    return args;
+}
+
+function assemblerFlags(project, product, input, output, explicitlyDependsOn) {
+    // Determine which C-language we're compiling
+    var tag = ModUtils.fileTagForTargetLanguage(input.fileTags.concat(output.fileTags));
+    if (!["asm"].contains(tag))
+        throw ("unsupported assembler language");
+
+    var args = [];
+    args.push(input.filePath);
+    args = args.concat(targetCores(input));
+
+    if (input.cpp.debugInformation)
+        args.push('-r');
+
+    var warnings = input.cpp.warningLevel
+    if (warnings === 'none')
+        args.push('-w-');
+    else
+        args.push('-w+');
+
+    // Enable sensitivity for user symbols.
+    args.push('-s+');
+
+    // ASM macro argument quotes.
+    args.push('-M<>');
+
+    args.push('-o', output.filePath);
+
+    args = args.concat(ModUtils.moduleProperty(input, 'platformFlags', tag),
+                       ModUtils.moduleProperty(input, 'flags', tag));
+    return args;
+}
+
+function linkerFlags(project, product, input, output) {
+    var i;
+    var args = [];
+
+    if (inputs.obj)
+        args = args.concat(inputs.obj.map(function(obj) { return obj.filePath }));
+
+    var redirects = [ '_Printf=_PrintfFull', '_Scanf=_ScanfFull' ];
+    for (i in redirects) {
+        args.push('--redirect');
+        args.push(redirects[i]);
+    }
+
+    args.push('-o', output.filePath);
+
+    var linkerScripts = inputs.linkerscript
+            ? inputs.linkerscript.map(function(a) { return a.filePath; }) : [];
+    for (i in linkerScripts) {
+        args.push('--config');
+        args.push(linkerScripts[i]);
+    }
+
+    if (product.cpp.debugInformation)
+        args.push('--semihosting');
+
+    // Program entry point.
+    var entryPoint = product.cpp.entryPoint
+            ? product.cpp.entryPoint : '__iar_program_start'
+    args.push('--entry');
+    args.push(entryPoint);
+
+    // Perform virtual function elimination.
+    args.push('--vfe');
+
+    return args;
+}
+
+function prepareCompiler(project, product, inputs, outputs, input, output, explicitlyDependsOn) {
+    var args = compilerFlags(project, product, input, output, explicitlyDependsOn);
+    var compilerPath = product.cpp.compilerPath;
+    var cmd = new Command(compilerPath, args)
+    cmd.description = 'compiling ' + input.fileName;
+    cmd.highlight = "compiler";
+    cmd.workingDirectory = product.buildDirectory;
+    cmd.responseFileUsagePrefix = '@';
+    return [cmd];
+}
+
+function prepareAssembler(project, product, inputs, outputs, input, output, explicitlyDependsOn) {
+    var args = assemblerFlags(project, product, input, output, explicitlyDependsOn);
+    var assemblerPath = product.cpp.assemblerPath;
+    var cmd = new Command(assemblerPath, args)
+    cmd.description = 'assembling ' + input.fileName;
+    cmd.highlight = "compiler";
+    cmd.workingDirectory = product.buildDirectory;
+    return [cmd];
+}
+
+function prepareLinker(project, product, inputs, outputs, input, output) {
+    var primaryOutput = outputs.application[0];
+    var args = linkerFlags(project, product, input, output);
+    var linkerPath = product.cpp.linkerPath;
+    var cmd = new Command(linkerPath, args)
+    cmd.description = 'linking ' + primaryOutput.fileName;
+    cmd.highlight = "linker";
+    cmd.workingDirectory = product.buildDirectory;
+    return [cmd];
+}

--- a/share/qbs/modules/cpp/iar.qbs
+++ b/share/qbs/modules/cpp/iar.qbs
@@ -86,6 +86,12 @@ CppModule {
             + " (enabled by default)"
     }
 
+    property bool generateMapFile: true
+    PropertyOptions {
+        name: "generateMapFile"
+        description: "produce a linker list file (enabled by default)"
+    }
+
     property string cpu;
     PropertyOptions {
         name: "cpu"
@@ -186,11 +192,24 @@ CppModule {
         multiplex: true
         inputs: ["obj", "linkerscript"]
 
-        Artifact {
-            fileTags: ['application']
-            filePath: FileInfo.joinPaths(
+        outputFileTags: ["application", "map_file"]
+                outputArtifacts: {
+            var app = {
+                fileTags: ["application"],
+                filePath: FileInfo.joinPaths(
                               product.destinationDirectory,
                               PathTools.applicationFilePath(product))
+            };
+            var artifacts = [app];
+            if (product.cpp.generateMapFile) {
+                artifacts.push({
+                    fileTags: ["map_file"],
+                filePath: FileInfo.joinPaths(
+                              product.destinationDirectory,
+                              product.targetName + '.map')
+                });
+            }
+            return artifacts;
         }
 
         prepare: {

--- a/share/qbs/modules/cpp/iar.qbs
+++ b/share/qbs/modules/cpp/iar.qbs
@@ -1,0 +1,193 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 Denis Shienkov <denis.shienkov@gmail.com>
+** Contact: http://www.qt.io/licensing
+**
+** This file is part of the Qt Build Suite.
+**
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms and
+** conditions see http://www.qt.io/terms-conditions. For further information
+** use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file.  Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, The Qt Company gives you certain additional
+** rights.  These rights are described in The Qt Company LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+****************************************************************************/
+
+import qbs 1.0
+import qbs.File
+import qbs.FileInfo
+import qbs.ModUtils
+import qbs.PathTools
+import qbs.Probes
+import qbs.Utilities
+import 'iar.js' as IAR
+
+CppModule {
+    condition: qbs.hostOS.contains('windows') &&
+               qbs.toolchain && qbs.toolchain.contains('iar')
+
+    Probes.BinaryProbe {
+        id: compilerPathProbe
+        condition: !toolchainInstallPath && !_skipAllChecks
+        names: ["iccarm"]
+    }
+
+    Probes.IarProbe {
+        id: iarProbe
+        condition: !_skipAllChecks
+        compilerFilePath: compilerPath
+        preferredArchitecture: qbs.architecture
+    }
+
+    qbs.architecture: iarProbe.found ? iarProbe.architecture : original
+
+    compilerVersionMajor: iarProbe.versionMajor
+    compilerVersionMinor: iarProbe.versionMinor
+    compilerVersionPatch: iarProbe.versionPatch
+    compilerIncludePaths: iarProbe.includePaths
+    endianness: iarProbe.endianness
+
+    compilerDefinesByLanguage: []
+
+    property string toolchainInstallPath: compilerPathProbe.found
+        ? compilerPathProbe.path : undefined
+
+    property bool enableCmsis: true
+    PropertyOptions {
+        name: "enableCmsis"
+        description: "enable/disable CMSIS support (enabled by default)"
+    }
+
+    property bool enableStaticDestruction;
+    PropertyOptions {
+        name: "enableStaticDestruction"
+        description: "don't emit code to destroy C++ static variables (disabled by default)"
+    }
+
+    property string cpu;
+    PropertyOptions {
+        name: "cpu"
+        description: "specify target CPU core (Cortex-M3 is default)"
+    }
+
+    property string fpu;
+    PropertyOptions {
+        name: "fpu"
+        description: "specify target FPU coprocessor support " +
+            "(default is none, which selects the software floating-point library)"
+    }
+
+    compilerName: {
+        switch (qbs.architecture) {
+        case "arm":
+            return "iccarm.exe";
+        default:
+            return "";
+        }
+    }
+    cCompilerName: compilerName
+    cxxCompilerName: compilerName
+    compilerPath: FileInfo.joinPaths(toolchainInstallPath, compilerName)
+
+    assemblerName: {
+        switch (qbs.architecture) {
+        case "arm":
+            return "iasmarm.exe";
+        default:
+            return "";
+        }
+    }
+    assemblerPath: FileInfo.joinPaths(toolchainInstallPath, assemblerName)
+
+    linkerName: {
+        switch (qbs.architecture) {
+        case "arm":
+            return "ilinkarm.exe";
+        default:
+            return "";
+        }
+    }
+    linkerPath: FileInfo.joinPaths(toolchainInstallPath, linkerName)
+
+    warningLevel: "default"
+    runtimeLibrary: "static"
+    separateDebugInformation: false
+    architecture: qbs.architecture
+    staticLibrarySuffix: ".a"
+    executableSuffix: ".out"
+    imageFormat: "elf"
+    enableExceptions: false
+    enableRtti: false
+
+    Rule {
+        id: assembler
+        inputs: ["asm"]
+
+        Artifact {
+            fileTags: ['obj']
+            filePath: Utilities.getHash(input.baseDir) + "/" + input.fileName + ".o"
+        }
+
+        prepare: {
+            return IAR.prepareAssembler.apply(IAR, arguments);
+        }
+    }
+
+    FileTagger {
+        patterns: "*.s"
+        fileTags: ["asm"]
+    }
+
+    Rule {
+        id: compiler
+        inputs: ["cpp", "c"]
+        auxiliaryInputs: ["hpp"]
+
+        Artifact {
+            fileTags: ['obj']
+            filePath: Utilities.getHash(input.baseDir) + "/" + input.fileName + ".o"
+        }
+
+        prepare: {
+            return IAR.prepareCompiler.apply(IAR, arguments);
+        }
+    }
+
+    Rule {
+        id: linker
+        multiplex: true
+        inputs: ["obj", "linkerscript"]
+
+        Artifact {
+            fileTags: ['application']
+            filePath: FileInfo.joinPaths(
+                              product.destinationDirectory,
+                              PathTools.applicationFilePath(product))
+        }
+
+        prepare: {
+            return IAR.prepareLinker.apply(IAR, arguments);
+        }
+    }
+
+    FileTagger {
+        patterns: "*.icf"
+        fileTags: ["linkerscript"]
+    }
+
+}

--- a/share/qbs/modules/cpp/iar.qbs
+++ b/share/qbs/modules/cpp/iar.qbs
@@ -79,6 +79,13 @@ CppModule {
         description: "don't emit code to destroy C++ static variables (disabled by default)"
     }
 
+    property bool enableSymbolsCaseSensitivity: true
+    PropertyOptions {
+        name: "enableSymbolsCaseSensitivity"
+        description: "enable/disable case sensitivity for user symbols"
+            + " (enabled by default)"
+    }
+
     property string cpu;
     PropertyOptions {
         name: "cpu"

--- a/share/qbs/modules/cpp/iar.qbs
+++ b/share/qbs/modules/cpp/iar.qbs
@@ -82,14 +82,20 @@ CppModule {
     property string cpu;
     PropertyOptions {
         name: "cpu"
-        description: "specify target CPU core (Cortex-M3 is default)"
+        description: "specify target CPU core support"
     }
 
     property string fpu;
     PropertyOptions {
         name: "fpu"
-        description: "specify target FPU coprocessor support " +
-            "(default is none, which selects the software floating-point library)"
+        description: "specify target FPU coprocessor support"
+    }
+
+    property string macroQuoteCharacters: "<>"
+    PropertyOptions {
+        name: "macroQuoteCharacters"
+        allowedValues: ["<>", "()", "[]", "{}"]
+        description: "assembler macro quote begin and end characters (default is <>)"
     }
 
     compilerName: {


### PR DESCRIPTION
This commit adds a basic support of the IAR toolchain for the
ARM processors on Windows host.

To use it with Qt Creator, it is enougth to add there a desired Kit
with a custom IAR C/C++ compilers, and then set to the Kit's QBS
custom properties page following:

* Key: qbs.toolchain
* Value: iar

Tested with EWARM v8.20.2 on Windows using STM NUCLEO-F767ZI
target board.

Change-Id: I3c42eb94051352cb3b7eb5b0768a1dc8bdacabce