### PR TITLE
show cached property values as diagnostic when command line conflicts

### DIFF
--- a/src/lib/corelib/buildgraph/buildgraphloader.cpp
+++ b/src/lib/corelib/buildgraph/buildgraphloader.cpp
@@ -868,9 +868,19 @@ bool BuildGraphLoader::checkConfigCompatibility()
     if (!m_parameters.overrideBuildGraphData()) {
         if (!m_parameters.overriddenValues().empty()
                 && m_parameters.overriddenValues() != restoredProject->overriddenValues) {
+            // build the list of overridden values for diagnostic purposes
+            QString overridden;
+            for(QVariantMap::const_iterator iter = restoredProject->overriddenValues.begin();
+                                            iter != restoredProject->overriddenValues.end();
+                                            ++iter) {
+                    overridden += QString::fromStdString("%1: %2\n").arg(iter.key(), iter.value().toString());
+            }
+
             throw ErrorInfo(Tr::tr("Property values set on the command line differ from the "
-                                   "ones used for the previous build. Use the 'resolve' command if "
-                                   "you really want to rebuild with the new properties."));
+                                   "ones used for the previous build. Cached properties are: \n%1"
+                                   "Use the 'resolve' command if "
+                                   "you really want to rebuild with the new properties.")
+                                   .arg(overridden));
             }
         m_parameters.setOverriddenValues(restoredProject->overriddenValues);
         if (m_parameters.topLevelProfile() != restoredProject->profile()) {


### PR DESCRIPTION
More than once I found myself wondering which properties were set in a previous build, so I [asked SO](https://stackoverflow.com/questions/68082087/determining-the-properties-used-by-a-previous-build) and the answer was not what I really expected.

So I digged a little bit on the sources and come out with this patch that helped me a lot, I hope it can be included in the project.
