### PR TITLE
Add building via conan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .qbs
 .vscode*
 build
+install
+package
 *.dll
 *.dylib
 *.exe

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "1.22.1":
+    url: "http://download.qt.io/official_releases/qbs/1.22.1/qbs-src-1.22.1.tar.gz"
+    sha256: b06003f49683971b552bb800bc134bf6c76cff79e1809cce741c40382b297b04
+
+patches:
+  "1.22.1":
+    - patch_file: "patches/0001-Allow-to-get-qbs-settings-dir-from-env-var.patch"
+    - patch_file: "patches/0002-Add-ability-to-bundle-qt-to-install-root-via-qmake.patch"

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,146 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+from os import path
+
+required_conan_version = ">=1.33.0"
+
+
+class QbsConan(ConanFile):
+    name = "qbs"
+    description = "The Qbs build system"
+    topics = ("qbs", "build", "tool")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://qbs.io"
+    license = "LGPL-2.1-only", "LGPL-3.0-only", "Nokia-Qt-exception-1.1"
+
+    short_paths = True
+    settings = "os", "arch", "compiler", "build_type"
+    exports = ["patches/*.patch"]
+
+    def validate(self):
+        if self.settings.os not in ["Linux", "Windows", "Macos"]:
+            raise ConanInvalidConfiguration(
+                "qbs supports Linux/Windows/macOS only.")
+
+        if self.settings.build_type not in ["Debug", "Release"]:
+            raise ConanInvalidConfiguration(
+                "qbs can be builed only as debug or release.")
+
+    def build_requirements(self):
+        self.tool_requires("qt/5.15.5")
+        if self.settings.compiler == "Visual Studio":
+            self.tool_requires("jom/1.1.3")
+
+    def configure(self):
+        self.options["qt"].gui = False
+        self.options["qt"].openssl = False
+        self.options["qt"].qtscript = True
+        self.options["qt"].shared = True
+        self.options["qt"].widgets = False
+        self.options["qt"].with_mysql = False
+        self.options["qt"].with_odbc = False
+        self.options["qt"].with_pcre2 = False
+        self.options["qt"].with_pq = False
+        self.options["qt"].with_sqlite3 = False
+        self.options["qt"].with_zstd = False
+
+        if self.settings.os == "Linux":
+            self.options["qt"].with_icu = False
+
+        minimal_cpp_standard = "11"
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, minimal_cpp_standard)
+
+        minimal_version = {
+            "gcc": "5.0",
+            "clang": "6.0",
+            "apple-clang": "11",
+            "Visual Studio": "16",
+        }
+
+        compiler = str(self.settings.compiler)
+        if compiler not in minimal_version:
+            self.output.warn(
+                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
+            self.output.warn(
+                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+            return
+
+        version = tools.Version(self.settings.compiler.version)
+        if version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration(
+                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True)
+
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+    @property
+    def _data(self):
+        data = {
+            'Linux': {
+                "build_tool": "make",
+                "frameworks": [],
+                "system_libs": ["m"],
+            },
+            'Macos': {
+                "build_tool": "make",
+                "frameworks": ["SystemConfiguration", "DiskArbitration", "CoreFoundation",
+                               "CFNetwork", "Foundation", "CoreServices", "IOKit", "Security",
+                               "ApplicationServices", "AppKit"],
+                "system_libs": [],
+            },
+            'Windows': {
+                "build_tool": "jom" if self.settings.compiler == "Visual Studio" else "mingw32-make",
+                "frameworks": [],
+                "system_libs": ["mpr", "psapi", "winmm", "winmm", "dnsapi",
+                                "iphlpapi", "netapi32", "userenv", "ws2_32", "ws2_32", "version"],
+            }
+        }
+
+        return data[str(self.settings.os)]
+
+    def build(self):
+        project_filepath = path.join(self.source_folder, "qbs.pro")
+        args = [
+            "-r", project_filepath,
+            "QT-=gui",
+            "CONFIG-=release",
+            "CONFIG-=debug",
+            "CONFIG-=debug_and_release",
+            "CONFIG+=%s" % str(self.settings.build_type).lower(),
+            "CONFIG+=nomake_tests",
+            "CONFIG+=qbs_no_dev_install",
+            "CONFIG+=qbs_no_man_install",
+            "CONFIG+=qbs_enable_bundled_qt",
+            "CONFIG+=no_qt_rpath",
+            "QBS_INSTALL_PREFIX=/"
+        ]
+        ncores = tools.cpu_count()
+
+        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+            self.run("qmake  %s" % ' '.join(args), run_environment=True)
+            self.run("%s -j%s" %
+                     (self._data['build_tool'], ncores), run_environment=True)
+
+    def package(self):
+        self.run("%s install INSTALL_ROOT=%s" %
+                 (self._data["build_tool"], self.package_folder))
+        # This recipe builds Qbs statically, the libs are not needed.
+        tools.rmdir(path.join(self.package_folder, "share", "qbs", "examples"))
+        self.copy(dst="licenses", pattern="LICENSE*")
+        self.copy(dst="licenses", pattern="LGPL*")
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def package_info(self):
+        binpath = path.join(self.package_folder, 'bin')
+        self.env_info.PATH.append(binpath)
+
+        self.cpp_info.includedirs = []
+
+        self.cpp_info.system_libs = self._data["system_libs"]
+        self.cpp_info.system_libs = self._data["frameworks"]

--- a/doc/qbs.qdoc
+++ b/doc/qbs.qdoc
@@ -557,6 +557,7 @@
                                         non-developer build.
     \row    \li qbs_no_man_install  \li Exclude the man page from installation.
     \row    \li qbs_use_bundled_qtscript        \li Use the bundled QtScript library.
+    \row    \li qbs_enable_bundled_qt        \li Bundle Qt to build and install folder.
     \endtable
 
     In addition, you can set the \c QBS_SYSTEM_SETTINGS_DIR environment variable

--- a/scripts/build-qbs-with-conan.sh
+++ b/scripts/build-qbs-with-conan.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#############################################################################
+##
+## Copyright (C) 2019 Richard Weickelt.
+## Contact: https://www.qt.io/licensing/
+##
+## This file is part of Qbs.
+##
+## $QT_BEGIN_LICENSE:LGPL$
+## Commercial License Usage
+## Licensees holding valid commercial Qt licenses may use this file in
+## accordance with the commercial license agreement provided with the
+## Software or, alternatively, in accordance with the terms contained in
+## a written agreement between you and The Qt Company. For licensing terms
+## and conditions see https://www.qt.io/terms-conditions. For further
+## information use the contact form at https://www.qt.io/contact-us.
+##
+## GNU Lesser General Public License Usage
+## Alternatively, this file may be used under the terms of the GNU Lesser
+## General Public License version 3 as published by the Free Software
+## Foundation and appearing in the file LICENSE.LGPL3 included in the
+## packaging of this file. Please review the following information to
+## ensure the GNU Lesser General Public License version 3 requirements
+## will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+##
+## GNU General Public License Usage
+## Alternatively, this file may be used under the terms of the GNU
+## General Public License version 2.0 or (at your option) the GNU General
+## Public license version 3 or any later version approved by the KDE Free
+## Qt Foundation. The licenses are as published by the Free Software
+## Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+## included in the packaging of this file. Please review the following
+## information to ensure the GNU General Public License requirements will
+## be met: https://www.gnu.org/licenses/gpl-2.0.html and
+## https://www.gnu.org/licenses/gpl-3.0.html.
+##
+## $QT_END_LICENSE$
+##
+#############################################################################
+set -e
+
+#
+# It might be desired to keep settings for Qbs testing
+# in a separate folder.
+#
+
+rm -rf build
+
+version=`cat VERSION`
+
+conan install -if build "$@" . "$version@_/_"
+conan build -bf build .
+conan export-pkg -bf build . "qbs/$version@_/_"

--- a/src/app/app.pro
+++ b/src/app/app.pro
@@ -5,6 +5,7 @@ SUBDIRS =\
     qbs-setup-android \
     qbs-setup-toolchains \
     qbs-setup-qt \
-    config
+    config \
+    ../shared/bundledqt
 
 !isEmpty(QT.widgets.name):SUBDIRS += config-ui

--- a/src/lib/corelib/corelib.pro
+++ b/src/lib/corelib/corelib.pro
@@ -34,6 +34,11 @@ win32:LIBS += -lpsapi -lshell32
 HEADERS += \
     qbs.h
 
+qbs_enable_bundled_qt {
+    linux-*: QMAKE_LFLAGS += -Wl,-z,origin \'-Wl,-rpath,\$\$ORIGIN\'
+    macos: QMAKE_LFLAGS += -Wl,-rpath,@loader_path
+}
+
 !qbs_no_dev_install {
     qbs_h.files = qbs.h
     qbs_h.path = $${QBS_INSTALL_PREFIX}/include/qbs

--- a/src/lib/corelib/tools/settingscreator.cpp
+++ b/src/lib/corelib/tools/settingscreator.cpp
@@ -53,14 +53,26 @@
 namespace qbs {
 namespace Internal {
 
+namespace {
+QString getBaseDir(QString baseDir) {
+    if (!baseDir.isEmpty())
+        return std::move(baseDir);
+
+    const char key[] = "QBS_SETTINGS_DIR";
+    if (qEnvironmentVariableIsSet(key))
+        return QLatin1String(qgetenv(key));
+
+    return QString();
+}
+}
+
 static QSettings::Format format()
 {
     return HostOsInfo::isWindowsHost() ? QSettings::IniFormat : QSettings::NativeFormat;
 }
 
-
 SettingsCreator::SettingsCreator(QString baseDir)
-    : m_settingsBaseDir(std::move(baseDir))
+    : m_settingsBaseDir(getBaseDir(std::move(baseDir)))
     , m_qbsVersion(Version::fromString(QLatin1String(QBS_VERSION)))
 {
 }

--- a/src/plugins/plugins.pri
+++ b/src/plugins/plugins.pri
@@ -1,6 +1,8 @@
 include(qbs_plugin_common.pri)
 
 TARGET = $$qbsPluginTarget
+win32:CONFIG(debug, debug|release):CONFIG(static, static|shared): \
+    TARGET = $${TARGET}d
 DESTDIR = $$qbsPluginDestDir
 
 isEmpty(QBSLIBDIR): QBSLIBDIR = $$OUT_PWD/../../../../$${QBS_LIBRARY_DIRNAME}

--- a/src/shared/bundledqt/bundledqt.pro
+++ b/src/shared/bundledqt/bundledqt.pro
@@ -1,0 +1,41 @@
+TEMPLATE = aux
+
+qbs_enable_bundled_qt {
+    !isEmpty(QBS_APPS_DESTDIR): bindir = $${QBS_APPS_DESTDIR}
+    else: bindir = bin
+
+    !isEmpty(QBS_LIBRARY_DIRNAME): libdir = $${QBS_LIBRARY_DIRNAME}
+    else: libdir = lib
+
+    win32: dstdir = $${bindir}
+    else: dstdir = $${libdir}
+    dstdir=$$shell_quote($$shell_path($$absolute_path($$dstdir,  $${OUT_PWD}/../../..)))
+
+    win32: bundled_qt.path = $${QBS_INSTALL_PREFIX}/$${bindir}
+    else: bundled_qt.path = $${QBS_INSTALL_PREFIX}/$${libdir}
+
+    target_qt_libs = Qt5Core Qt5Xml Qt5Network Qt5Script
+    bundled_qt_at_build.target = bundled_qt_libs
+
+    for(lib, target_qt_libs) {
+        win32: srcdir = $$[QT_INSTALL_BINS]
+        else: srcdir = $$[QT_INSTALL_LIBS]
+        srcdir = $$shell_quote($$shell_path($${srcdir}))
+
+        win32: file = "$${lib}.dll"
+        macos: file = "lib$${lib}*.dylib"
+        linux-*: file = "lib$${lib}.so*"
+        file = $$shell_path($$absolute_path($${file}, $${srcdir}))
+
+        win32:bundled_qt.files += $${file}
+        else: bundled_qt.extra += $${QMAKE_COPY} -P $${file} $(INSTALL_ROOT)/$${bundled_qt.path} $$escape_expand(\n\t)
+
+        !win32: copy_flags = -P
+        bundled_qt_at_build.commands += $${QMAKE_COPY} $${copy_flags} $${file} $${dstdir} $$escape_expand(\n\t)
+    }
+
+    QMAKE_EXTRA_TARGETS += bundled_qt_at_build
+    PRE_TARGETDEPS += $${bundled_qt_at_build.target}
+
+    INSTALLS += bundled_qt
+}


### PR DESCRIPTION
Hi! 

My team using qbs as main build system in our projects. Recently we decided to pack all our dependencies via conan package manager. Qbs is also our dependency, so, we decided to pack it too.

I wrote conanfile.py for your project, which allows to build qbs with qt downloaded from conancenter and after building pack it to conan package. This package may be used as building tool in another projects:
```bash
conan install qbs/1.23.0@_/_ -g virtualenv -if install
source install/activate.sh
qbs --version
source install/deactivate.sh
```

I already manually tested using this package on Linux, Windows and Macos system, but think that will be better automate this process.

Except adding conanfile, I also 
1. Fix some problem with 'd' suffix of debug plugins on windows
2. Enable to specify user settings dir via environment variable. I think this feature will be useful for using packed qbs

What do you think about that?