### PR TITLE
Visual Studio generator plugin: Remove duplication of dependencies for solution

### DIFF
--- a/src/lib/msbuild/io/visualstudiosolutionwriter.cpp
+++ b/src/lib/msbuild/io/visualstudiosolutionwriter.cpp
@@ -108,20 +108,6 @@ bool VisualStudioSolutionWriter::write(const VisualStudioSolution *solution)
             << project->guid().toString().toStdString()
             << u8"\"\n";
 
-        const auto dependencies = solution->dependencies(project);
-        if (!dependencies.empty()) {
-            out << u8"\tProjectSection(ProjectDependencies) = postProject\n";
-
-            for (const auto &dependency : dependencies)
-                out << u8"\t\t"
-                    << dependency->guid().toString().toStdString()
-                    << u8" = "
-                    << dependency->guid().toString().toStdString()
-                    << u8"\n";
-
-            out << u8"\tEndProjectSection\n";
-        }
-
         out << u8"EndProject\n";
     }
 


### PR DESCRIPTION
Duplication of project dependencies in the .sln file results in Visual Studio checking the need to build dependencies every time the project is launched, even if no changes have been made. With a large number of dependencies, this can take a lot of time. Since Visual Studio transfers control over the build directly to QBS, it will independently check and perform the dependencies build.